### PR TITLE
Closes #17, #16, #8, and #4

### DIFF
--- a/PrismaticWarning/PrismaticWarning.lua
+++ b/PrismaticWarning/PrismaticWarning.lua
@@ -71,7 +71,7 @@ end
 function PrismaticWarning.OnActivityFinderStatusUpdate(_, result) -- Thank you @code65536 (stolen from dungeon timer)
 	-- Covers the case where a group requeues directly into the same dungeon
 	if (result == ACTIVITY_FINDER_STATUS_FORMING_GROUP or result == ACTIVITY_FINDER_STATUS_READY_CHECK) then
-		PrismaticWarning.dungeonComplete()
+		PrismaticWarning.dungeonComplete(false)
 	end
 end
 
@@ -93,10 +93,10 @@ function PrismaticWarning.sorter()
 
   if PrismaticWarning.zoneId ~= zoneId then
     PrismaticWarning.zoneId = zoneId
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(false)
   elseif PrismaticWarning.settingsBypass then
     PrismaticWarning.settingsBypass = false
-    PrismaticWarning.dungeonComplete() -- in case shouldWatch is now false
+    PrismaticWarning.dungeonComplete(false) -- in case shouldWatch is now false
   else
     return -- already checked this zone and settings haven't changed
   end
@@ -168,7 +168,7 @@ function PrismaticWarning.AA() -- alerts slightly late, as in not on pads to fou
     PrismaticWarning.alerter(true)
   elseif mapId == 641 or mapId == 640 then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -178,7 +178,7 @@ function PrismaticWarning.BC1()
   local x, y = PrismaticWarning.currentLocation()
   if x < 38 and y > 32 then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(true)
   end
@@ -190,7 +190,7 @@ function PrismaticWarning.BC2()
     PrismaticWarning.alerter(false)
   elseif x < 43 and y < 20 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(true)
   end
@@ -205,7 +205,7 @@ function PrismaticWarning.BHH()
     PrismaticWarning.alerter(true)
   elseif y < 10 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -215,7 +215,7 @@ function PrismaticWarning.BRF()
   local _, y = PrismaticWarning.currentLocation()
   if PrismaticWarning.specialEventTrigger then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   elseif GetCurrentMapId() == 1309 and y > 63 then
     PrismaticWarning.caresAboutXPGain = true
     PrismaticWarning.alerter(false)
@@ -228,7 +228,7 @@ function PrismaticWarning.COA1()
   local x, y = PrismaticWarning.currentLocation()
   if x > 50 then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   -- elseif x < 22 and y > 58 then -- Golor technically isn't an undead/daedra, but he dies so quickly it'll slow groups down if they unequip, then re-equip the prismatic
     -- PrismaticWarning.alerter(false)
   else
@@ -236,17 +236,17 @@ function PrismaticWarning.COA1()
   end
 end
 
-function PrismaticWarning.COS() -- double check alerts
+function PrismaticWarning.COS()
   local x, y = PrismaticWarning.currentLocation()
   local mapId = GetCurrentMapId()
   
-  if mapId == 1134 and ((y > 60 and x > 65) or (x < 34 and y < 65)) then
+  if mapId == 1134 and ((y > 66 and x > 76) or (x < 30 and y < 60)) then
     PrismaticWarning.alerter(true)
-  elseif mapId == 1135 and y > 53 then -- Replace "y > 53" with "dranos is dead" if that's a thing without needed to register for combat events. Gives user more time to equip the weapon
+  elseif mapId == 1135 and (y > 56 or x > 58) then
     PrismaticWarning.alerter(true)
-  elseif mapId == 1137 then
+  elseif mapId == 1136 or mapId == 1137 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -258,7 +258,7 @@ function PrismaticWarning.CT()
   
   if mapId == 1823 and x < 38 or y < 38 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -287,7 +287,7 @@ function PrismaticWarning.DOM()
     end
   else
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   end
 end
 
@@ -297,7 +297,7 @@ function PrismaticWarning.DSA()
     PrismaticWarning.alerter(true)
   elseif mapId == 692 then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -309,7 +309,7 @@ function PrismaticWarning.EH2()
     PrismaticWarning.alerter(false)
   elseif y < 33 and x < 55 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(true)
   end
@@ -320,7 +320,7 @@ function PrismaticWarning.FG2()
   
   if GetCurrentMapId() == 1151 or x < 34 or (y > 46 and y < 50 and x < 39) then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   elseif y > 38 and y < 50 and x < 45 then
     PrismaticWarning.alerter(true)
   else
@@ -334,7 +334,7 @@ function PrismaticWarning.FH()
   if mapId == 1322 then
     if x > 59 and y > 78 then
       PrismaticWarning.alerter(false)
-      PrismaticWarning.dungeonComplete()
+      PrismaticWarning.dungeonComplete(true)
     else
       PrismaticWarning.alerter(true)
     end
@@ -342,7 +342,7 @@ function PrismaticWarning.FH()
     PrismaticWarning.alerter(true)
   elseif mapId == 1323 then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -351,7 +351,7 @@ end
 function PrismaticWarning.FullDungeon()
   PrismaticWarning.alerter(true)
   if PrismaticWarning.isPrismaticEquipped then
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   end
 end
 
@@ -361,7 +361,7 @@ function PrismaticWarning.HRC()
   
   if mapId == 616 or PrismaticWarning.counter > 0 then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   elseif mapId == 615 and y > 52 and PrismaticWarning.specialEventTrigger then
     PrismaticWarning.alerter(true)
   else
@@ -373,7 +373,7 @@ end
 function PrismaticWarning.KA()
   if GetCurrentMapId() == 1806 then -- 1807 is the 2nd floor, 1808 is the bottom floor
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -385,7 +385,7 @@ function PrismaticWarning.MA()
     PrismaticWarning.alerter(true)
   elseif mapId == 986 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -396,7 +396,7 @@ function PrismaticWarning.MOL()
   
   if GetCurrentMapId()== 1000 and x < 75 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -405,7 +405,7 @@ end
 function PrismaticWarning.NoneDungeon()
   PrismaticWarning.alerter(false)
   if not PrismaticWarning.isPrismaticEquipped then
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   end
 end
 
@@ -413,7 +413,7 @@ function PrismaticWarning.Spindle1()
   local _, y = PrismaticWarning.currentLocation()
   if y > 68 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -423,7 +423,7 @@ function PrismaticWarning.Spindle2()
   local x, y = PrismaticWarning.currentLocation()
   if x > 70 or y > 55 then
     PrismaticWarning.alerter(true)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   elseif x > 52 and y < 33 then
     PrismaticWarning.alerter(false)
   else
@@ -437,7 +437,7 @@ function PrismaticWarning.Tempest()
     PrismaticWarning.alerter(true)
   elseif GetCurrentMapId() == 597 then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -451,7 +451,7 @@ function PrismaticWarning.UHG()
     PrismaticWarning.alerter(true)
   elseif mapId == 1796 and y > 75 then
     PrismaticWarning.alerter(false)
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
   else
     PrismaticWarning.alerter(false)
   end
@@ -465,7 +465,7 @@ function PrismaticWarning.VH()
   elseif mapId == 1844 then
     PrismaticWarning.alerter(false)
   elseif mapId == 1846 then
-    PrismaticWarning.dungeonComplete()
+    PrismaticWarning.dungeonComplete(true)
     PrismaticWarning.alerter(false)
   end
 end
@@ -554,11 +554,12 @@ function PrismaticWarning.alerter(shouldEquip)
       whatToDo = GetString(PRISMATICWARNING_UNEQUIP_NOW)
       PrismaticWarning.alert = true
     else
-      whatToDo = GetString(PRISMATICWARNING_KEEP_AS_IS)
       PrismaticWarning.alert = false
     end
     
-    PrismaticWarning.addChatMessage(whatToDo)
+    if whatToDo ~= nil then
+      PrismaticWarning.addChatMessage(whatToDo)
+    end
     
     if PrismaticWarning.savedVariables.autoSwapTo == GetString(PRISMATICWARNING_MENU_DONT) then
       PrismaticWarning.alertVisible(PrismaticWarning.alert, whatToDo)
@@ -601,9 +602,11 @@ function PrismaticWarning.currentLocation()
   return x * 100, y * 100
 end
 
-function PrismaticWarning.dungeonComplete()
-  PrismaticWarning.debugAlert("Complete")
-  PrismaticWarning.addChatMessage(GetString(PRISMATICWARNING_DONE_WATCHING))
+function PrismaticWarning.dungeonComplete(dungeonEnd)
+  if dungeonEnd then
+    PrismaticWarning.debugAlert("Complete")
+    PrismaticWarning.addChatMessage(GetString(PRISMATICWARNING_DONE_WATCHING))
+  end
   EVENT_MANAGER:UnregisterForUpdate(PrismaticWarning.name)
   EVENT_MANAGER:UnregisterForEvent(PrismaticWarning.name .. "Death", EVENT_UNIT_DEATH_STATE_CHANGED)
   EVENT_MANAGER:UnregisterForEvent(PrismaticWarning.name .. "XPGained", EVENT_EXPERIENCE_GAIN)

--- a/PrismaticWarning/lang/en.lua
+++ b/PrismaticWarning/lang/en.lua
@@ -3,12 +3,11 @@ local strings = {
   -- Alert --
   PRISMATICWARNING_ALERT = "Prismatic",
   PRISMATICWARNING_EQUIP_NOW = "Equip one now",
-  PRISMATICWARNING_KEEP_AS_IS = "Keep it as is",
   PRISMATICWARNING_UNEQUIP_NOW = "Unequip it now",
   PRISMATICWARNING_AUTO_SWAP_FAILED = "Failed to Auto-Swap weapons",
   
   -- Chat Only --
-  PRISMATICWARNING_AUTO_SWAP_SUCCESS = "Successfully Auto-Swapped weapons",
+  PRISMATICWARNING_AUTO_SWAP_SUCCESS = "Successfully auto-swapped weapons",
   PRISMATICWARNING_WATCHING = "You will need a prismatic weapon, you should grab one now",
   PRISMATICWARNING_DONE_WATCHING = "There are no more changes this dungeon",
   

--- a/PrismaticWarning/lang/new.lua
+++ b/PrismaticWarning/lang/new.lua
@@ -4,12 +4,11 @@ local strings = {
   -- All strings in this category have a maximum length, please check they aren't too long
   PRISMATICWARNING_ALERT = "Prismatic", -- referring to a weapon with a glyph of prismatic onslaught
   PRISMATICWARNING_EQUIP_NOW = "Equip one now",
-  PRISMATICWARNING_KEEP_AS_IS = "Keep it as is",
   PRISMATICWARNING_UNEQUIP_NOW = "Unequip it now",
   PRISMATICWARNING_AUTO_SWAP_FAILED = "Failed to Auto-Swap weapons",
   
   -- Chat Only --
-  PRISMATICWARNING_AUTO_SWAP_SUCCESS = "Successfully Auto-Swapped weapons",
+  PRISMATICWARNING_AUTO_SWAP_SUCCESS = "Successfully auto-swapped weapons",
   PRISMATICWARNING_WATCHING = "You will need a prismatic weapon, you should grab one now",
   PRISMATICWARNING_DONE_WATCHING = "There are no more changes this dungeon",
   


### PR DESCRIPTION
- Removed keep it as is alert since it is not something the user needs to do
- Fixed spelling error in auto-swap success
- Made chat alerts on dungeonComplete not alert unless a dungeon was complete (it's also used to reset on travel)
- Fixed Cradle of Shadows delayed alert and incorrect alerts

Closes #17, #16, #8, and #4