### PR TITLE
Fixed #24

### DIFF
--- a/PrismaticWarning/PrismaticWarning.lua
+++ b/PrismaticWarning/PrismaticWarning.lua
@@ -622,8 +622,10 @@ function PrismaticWarning.dungeonComplete(endOfDungeon, shouldSlot)
         PrismaticWarning.alert = false
       end
       
-      PrismaticWarning.addChatMessage(whatToDo)
-      PrismaticWarning.alertVisible(false, whatToDo)
+      if PrismaticWarning.alert then
+        PrismaticWarning.addChatMessage(whatToDo)
+        PrismaticWarning.alertVisible(false, whatToDo)
+      end
     end
     PrismaticWarning.debugAlert("Complete")
     PrismaticWarning.addChatMessage(GetString(PRISMATICWARNING_DONE_WATCHING))


### PR DESCRIPTION
Added modified alerter() code to dungeonEnd's endOfDungeon that will assess if they should swap weapons, and if they should:
- Set the on-screen alert text to what it should be without popping up the alert
- Set the alert status to what it should be so that when the user exits combat after crossing the final boundary, the on-screen alert will pop up if needed
- Push out a chat message with what weapon they should change to
- Doesn't call auto-equipper to avoid errors

Closes #24 